### PR TITLE
Replace `!=` with `not=`

### DIFF
--- a/src/zprint/config.cljc
+++ b/src/zprint/config.cljc
@@ -294,7 +294,7 @@
    "and" :hang,
    "or" :hang,
    "=" :hang,
-   "!=" :hang,
+   "not=" :hang,
    "try" :none-body,
    "catch" :arg2,
    "with-meta" :arg1-body,


### PR DESCRIPTION
I think that's what you meant, as there is no `!=` in the core library. Feel free to reject this if it's not the case.