### PR TITLE
Use "body" indentation for the ns macro

### DIFF
--- a/src/zprint/config.cljc
+++ b/src/zprint/config.cljc
@@ -273,7 +273,7 @@
 ;;
 
 (def zfnstyle
-  {"ns" :arg1,
+  {"ns" :arg1-body,
    "let" :binding,
    "if" :arg1-body,
    "if-not" :arg1-body,


### PR DESCRIPTION
By convention, namespace decls are indented with two spaces for
everything following the ns name, effectively turning the additional
args into "body" arguments.

This commit causes ns to be indented like when, even when using community
style.

Closes #13 