### PR TITLE
add shebang to build.zprintm

### DIFF
--- a/build.zprintm
+++ b/build.zprintm
@@ -1,3 +1,4 @@
+#!/bin/bash
 export PATH=$PATH:$1/Contents/Home/bin
 export JAVA_HOME=$1/Contents/Home
 native-image -jar $2 -H:Name="$3" -H:+ReportUnsupportedElementsAtRuntime


### PR DESCRIPTION
Without this I got the following error:

```
./build.zprintm graalvm-1.0.0-rc1 zprint-filter-0.4.9 zprint
Failed to execute process './build.zprintm'. Reason:
exec: Exec format error
The file './build.zprintm' is marked as an executable but could not be run by the operating system.
```

I also had to make the file executable... maybe I misunderstood the docs and this shouldn't be required?