### PR TITLE
Add Clojure CLI section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,22 @@ following environments:
 It requires `tools.reader` at least 1.0.5, which all of the environments
 above contain.
 
+### Clojure CLI
+
+Add the following either to the `$HOME/.clojure/deps.edn` file or to a project `deps.edn`:
+
+```clojure
+:zprint {:extra-deps {org.clojure/clojure {:mvn/version "1.9.0"}
+                      zprint              {:mvn/version "0.4.13"}}
+         :main-opts  ["-m" "zprint.main"]}
+```	    
+
+Then you can use the following as filter and pretty printer:
+
+```shell
+cat /path/to/file.clj | clojure -A:zprint
+```
+
 ## Features
 
 In addition to meeting the goals listed above, zprint has the 


### PR DESCRIPTION
Hi @kkinnear!

I had a bit of trouble to understand that the Clojure CLI usage acts like a filter, waiting on input stream, so I am opening this PR in order to add an example in the README.

I hope this is a good place for it.

An idea I have also had is to split the README into the wiki, with sections and toc. It would of course make it smaller :smile: 

Anyway, thank you for your work on `zprint`!
