### PR TITLE
Add :option-fn and :fn-format to :vector to support better hiccup formatting

### DIFF
--- a/src/zprint/config.cljc
+++ b/src/zprint/config.cljc
@@ -615,7 +615,7 @@
             :binding? false,
             :option-fn-first nil,
             :option-fn nil,
-            :fn-format nil
+            :fn-format nil,
             :respect-nl? false,
             :wrap-after-multi? true,
             :wrap-coll? true,
@@ -629,7 +629,7 @@
                :hang? true,
                :indent 2,
                :indent-arg nil,
-               :pair-hang? true}
+               :pair-hang? true},
    :width 80,
    :zipper? false})
 

--- a/src/zprint/config.cljc
+++ b/src/zprint/config.cljc
@@ -614,10 +614,22 @@
    :vector {:indent 1,
             :binding? false,
             :option-fn-first nil,
+            :option-fn nil,
+            :fn-format nil
             :respect-nl? false,
             :wrap-after-multi? true,
             :wrap-coll? true,
             :wrap? true},
+   :vector-fn {:constant-pair-min 4,
+               :constant-pair? true,
+               :hang-avoid 0.5,
+               :hang-diff 1,
+               :hang-expand 2.0,
+               :hang-size 100,
+               :hang? true,
+               :indent 2,
+               :indent-arg nil,
+               :pair-hang? true}
    :width 80,
    :zipper? false})
 

--- a/src/zprint/spec.cljc
+++ b/src/zprint/spec.cljc
@@ -147,6 +147,8 @@
 (s/def ::surround (s/nilable (s/coll-of number? :kind sequential?)))
 (s/def ::additional-libraries? ::boolean)
 (s/def ::option-fn-first (s/nilable fn?))
+(s/def ::option-fn (s/nilable fn?))
+(s/def ::fn-format (s/nilable ::fn-type))
 (s/def ::record-type? ::boolean)
 (s/def ::respect-nl? ::boolean)
 (s/def ::size number?)
@@ -213,6 +215,8 @@
   (only-keys :opt-un [::constant-pair-min ::constant-pair? ::hang-diff
                       ::hang-avoid ::hang-expand ::hang-size ::hang? ::indent
                       ::indent-arg ::pair-hang? ::return-altered-zipper]))
+(s/def ::vector-fn ::list)
+
 (s/def ::map
   (only-keys :opt-un [::comma? ::flow? ::force-nl? ::hang-adjust ::hang-diff
                       ::hang-expand ::hang? ::indent ::justify? ::justify-hang
@@ -265,6 +269,7 @@
 (s/def ::user-fn-map ::fn-map-value)
 (s/def ::vector
   (only-keys :opt-un [::indent ::binding? ::respect-nl? ::option-fn-first
+                      ::option-fn ::fn-format
                       ::wrap-after-multi? ::wrap-coll? ::wrap?]))
 (s/def ::version string?)
 (s/def ::width number?)
@@ -288,7 +293,7 @@
              ::perf-vs-format ::process-bang-zprint? ::promise ::reader-cond
              ::record ::remove ::return-cvec? ::search-config? ::set ::spaces?
              ::spec ::style ::style-map ::tab ::trim-comments? ::tuning
-             :alt/uneval ::user-fn-map ::vector ::version ::width ::zipper?]))
+             :alt/uneval ::user-fn-map ::vector ::vector-fn ::version ::width ::zipper?]))
 
 (defn numbers-or-number-pred?
   "If they are both numbers and are equal, or the first is a number 

--- a/src/zprint/spec.cljc
+++ b/src/zprint/spec.cljc
@@ -269,8 +269,8 @@
 (s/def ::user-fn-map ::fn-map-value)
 (s/def ::vector
   (only-keys :opt-un [::indent ::binding? ::respect-nl? ::option-fn-first
-                      ::option-fn ::fn-format
-                      ::wrap-after-multi? ::wrap-coll? ::wrap?]))
+                      ::option-fn ::fn-format ::wrap-after-multi? ::wrap-coll?
+                      ::wrap?]))
 (s/def ::version string?)
 (s/def ::width number?)
 (s/def ::zipper? ::boolean)
@@ -281,19 +281,19 @@
 
 (s/def ::options
   (only-keys
-    :opt-un [::additional-libraries? ::agent ::array ::atom ::auto-width?
-             ::binding ::color? ::color-map :alt/comment ::configured? ::dbg?
-             ::cwd-zprintrc? ::dbg-bug? ::dbg-print? ::dbg-ge ::delay
-             ::do-in-hang? ::drop? ::extend ::file? ::fn-force-nl
-             ::fn-gt2-force-nl ::fn-gt3-force-nl ::fn-map ::fn-name ::fn-obj
-             ::format ::future ::indent ::list ::map ::max-depth
-             ::max-depth-string ::max-hang-count ::max-hang-depth
-             ::max-hang-span ::max-length ::object ::old? ::output ::pair
-             ::pair-fn ::parallel? ::parse ::parse-string-all? ::parse-string?
-             ::perf-vs-format ::process-bang-zprint? ::promise ::reader-cond
-             ::record ::remove ::return-cvec? ::search-config? ::set ::spaces?
-             ::spec ::style ::style-map ::tab ::trim-comments? ::tuning
-             :alt/uneval ::user-fn-map ::vector ::vector-fn ::version ::width ::zipper?]))
+    :opt-un
+      [::additional-libraries? ::agent ::array ::atom ::auto-width? ::binding
+       ::color? ::color-map :alt/comment ::configured? ::dbg? ::cwd-zprintrc?
+       ::dbg-bug? ::dbg-print? ::dbg-ge ::delay ::do-in-hang? ::drop? ::extend
+       ::file? ::fn-force-nl ::fn-gt2-force-nl ::fn-gt3-force-nl ::fn-map
+       ::fn-name ::fn-obj ::format ::future ::indent ::list ::map ::max-depth
+       ::max-depth-string ::max-hang-count ::max-hang-depth ::max-hang-span
+       ::max-length ::object ::old? ::output ::pair ::pair-fn ::parallel?
+       ::parse ::parse-string-all? ::parse-string? ::perf-vs-format
+       ::process-bang-zprint? ::promise ::reader-cond ::record ::remove
+       ::return-cvec? ::search-config? ::set ::spaces? ::spec ::style
+       ::style-map ::tab ::trim-comments? ::tuning :alt/uneval ::user-fn-map
+       ::vector ::vector-fn ::version ::width ::zipper?]))
 
 (defn numbers-or-number-pred?
   "If they are both numbers and are equal, or the first is a number 

--- a/src/zprint/zprint.cljc
+++ b/src/zprint/zprint.cljc
@@ -3044,7 +3044,8 @@
               errors))
       options)))
 
-(defn lazy-sexpr-seq [nws-seq]
+(defn lazy-sexpr-seq
+  [nws-seq]
   (if (seq nws-seq)
     (lazy-cat [(zsexpr (first nws-seq))] (lazy-sexpr-seq (rest nws-seq)))
     []))
@@ -3054,8 +3055,8 @@
   print them."
   [caller l-str r-str
    {:keys [rightcnt in-code?],
-    {:keys [wrap-coll? wrap? binding? option-fn-first option-fn respect-nl? sort?
-            fn-format sort-in-code?]}
+    {:keys [wrap-coll? wrap? binding? option-fn-first option-fn respect-nl?
+            sort? fn-format sort-in-code?]}
       caller,
     :as options} ind zloc]
   (if (and binding? (= (:depth options) 1))
@@ -3068,15 +3069,16 @@
                             (option-fn-first options first-sexpr)
                             (str ":vector :option-fn-first called with "
                                  first-sexpr))))
-          new-options (if option-fn
-                        (let [nws-seq   (remove zwhitespaceorcomment? (zseqnws zloc))
-                              nws-count (count nws-seq)
-                              sexpr-seq (lazy-sexpr-seq nws-seq)]
-                          (internal-validate
-                            (option-fn new-options nws-count sexpr-seq)
-                            (str ":vector :option-fn called with sexpr count "
-                                 nws-count)))
-                        new-options)
+          new-options
+            (if option-fn
+              (let [nws-seq (remove zwhitespaceorcomment? (zseqnws zloc))
+                    nws-count (count nws-seq)
+                    sexpr-seq (lazy-sexpr-seq nws-seq)]
+                (internal-validate
+                  (option-fn new-options nws-count sexpr-seq)
+                  (str ":vector :option-fn called with sexpr count "
+                       nws-count)))
+              new-options)
           #_(prn "new-options:" new-options)
           {{:keys [wrap-coll? wrap? binding? option-fn-first respect-nl? sort?
                    fn-format sort-in-code?]}
@@ -3086,35 +3088,46 @@
       (if fn-format
         ; Formatting entire vector as function, use list formatting
         ; with the given fn-style and ignore all other vector settings
-        (fzprint-list* :vector-fn "[" "]" (assoc options :fn-style fn-format) ind zloc)
+        (fzprint-list* :vector-fn
+                       "["
+                       "]"
+                       (assoc options :fn-style fn-format)
+                       ind
+                       zloc)
         (let [; If sort? is true, then respect-nl? makes no sense.  At present,
-              ; sort? and respect-nl? are not both supported for the same structure,
-              ; so this doesn't really matter, but if in the future they were, this
+              ; sort? and respect-nl? are not both supported for the same
+              ; structure,
+              ; so this doesn't really matter, but if in the future they were,
+              ; this
               ; would help.
-              respect-nl?    (and respect-nl? (not sort?))
-              new-ind        (+ (count l-str) ind)
-              _              (dbg-pr options "fzprint-vec*:" (zstring zloc) "new-ind:" new-ind)
+              respect-nl? (and respect-nl? (not sort?))
+              new-ind (+ (count l-str) ind)
+              _ (dbg-pr options
+                        "fzprint-vec*:" (zstring zloc)
+                        "new-ind:" new-ind)
               zloc-seq
-                             (if respect-nl? (zmap-w-nl identity zloc) (zmap identity zloc))
-              zloc-seq       (if (and sort? (if in-code? sort-in-code? true))
-                               (order-out caller options identity zloc-seq)
-                               zloc-seq)
-              coll-print     (if (zero? (zcount zloc))
-                               [[["" :none :whitespace]]]
-                               (fzprint-seq options new-ind zloc-seq))
-              _              (dbg-pr options "fzprint-vec*: coll-print:" coll-print)
-              ; If we got any nils from fzprint-seq and we were in :one-line mode
+                (if respect-nl? (zmap-w-nl identity zloc) (zmap identity zloc))
+              zloc-seq (if (and sort? (if in-code? sort-in-code? true))
+                         (order-out caller options identity zloc-seq)
+                         zloc-seq)
+              coll-print (if (zero? (zcount zloc))
+                           [[["" :none :whitespace]]]
+                           (fzprint-seq options new-ind zloc-seq))
+              _ (dbg-pr options "fzprint-vec*: coll-print:" coll-print)
+              ; If we got any nils from fzprint-seq and we were in :one-line
+              ; mode
               ; then give up -- it didn't fit on one line.
-              coll-print     (if-not (contains-nil? coll-print) coll-print)
-              one-line       (when coll-print
-                               ; should not be necessary with contains-nil? above
-                               (apply concat-no-nil
-                                      (interpose [[" " :none :whitespace]]
-                                                 ; This causes single line things to also respect-nl
-                                                 ; when it is enabled.  Could be separately controlled
-                                                 ; instead of with :respect-nl? if desired.
-                                                 (if respect-nl? coll-print (remove-nl coll-print)))))
-              _              (log-lines options "fzprint-vec*:" new-ind one-line)
+              coll-print (if-not (contains-nil? coll-print) coll-print)
+              one-line
+                (when coll-print
+                  ; should not be necessary with contains-nil? above
+                  (apply concat-no-nil
+                    (interpose [[" " :none :whitespace]]
+                      ; This causes single line things to also respect-nl
+                      ; when it is enabled.  Could be separately controlled
+                      ; instead of with :respect-nl? if desired.
+                      (if respect-nl? coll-print (remove-nl coll-print)))))
+              _ (log-lines options "fzprint-vec*:" new-ind one-line)
               one-line-lines (style-lines options new-ind one-line)]
           (when one-line-lines
             (if (fzfit-one-line options one-line-lines)


### PR DESCRIPTION
Hi and thanks for this awesome library!

First, I don't expect this PR to get merged as it is but to (hopefully) lead to some improvements for hiccup (and also generic vector) formatting support. 😊 

I've been using this happily to format my backend sources. Lately I've also been wondering, how could I use this in my frontend as well. But hiccup causes me some troubles. I've been using `:option-fn-first` + `:respect-nl?` combo which works quite well with hiccups but leaves too much options for individual developers to decide the formatting. Using `:wrap? false` works also pretty well but it lacks the proper formatting of element/component props map e.g. cases
```cljs
[:button {:on-click #(println "lolbal")}
  [icons/star]
  "Star me!"]

[:button {:on-click #(println "lolbal")}
  [icons/star {:style {:color colors/yellow}}]
  "Star me!"]
``` 

Formats into sources:
```cljs
;; everything to single line
[:button {:on-click #(println "lolbal")} [icons/star] "Star me!"]

;; props "vanish" to children, would be better to position 
;; right after :button if possible
[:button
 {:on-click #(println "lolbal")}
 [icons/star {:style {:color colors/yellow}}]
 "Star me!"]
```

Thinking a while, it came to my mind that the (IMHO) "optimal" hiccup formatting follows pretty much `:arg1-body` or `:arg1-force-nl` function formatting. Of course it has some drawbacks as well but general cases look pretty good. However, there were two obstacles to achieve this: (1) `:vector` does not support function style formatting (2) in order to hiccup keep false positives as few as possible, the decision should be made based on vector's second argument (props map) and this is not possible with `:option-fn-first`.

So in order to support my use case, I added two new options for `:vector` 

* `:option-fn` which is a generalization of `:option-fn-first`, taking 3 arguments `[opts n-vec-elems elem-sexprs]`
* `:fn-format` which takes a keyword satisfying `::spec/fn-type` and overrides all other vector options if present

Both of these options are set to `nil` by default, which preserves the backwards compatibility. `:option-fn` third argument is implemented as lazy sequence (thus the second "count" argument) in order to avoid unnecessary sexpr conversion. `:fn-format` uses `zprint-list*` to apply the function formatting. New `:vector-fn` top level configuration is reserved for this purpose and uses same defaults as `:list`. 

The changes are relatively small, although the formatting causes a lot of actual LOC changes. I've separated the "beef" into [the first commit](https://github.com/kkinnear/zprint/commit/44f2f226f5ea559c81bc360e4c5a5fb34bb0f85b) and done formatting in the second. I haven't written any tests or docs yet, because it thought it would be nice to discuss about these features first.

But back to my own use case. I've played with different options and especially this combo seems to give me very good results:

```cljs
{:vector
 {:wrap? false,
  :option-fn (fn [opts n exprs]
               (let [hiccup? (and (>= n 2)
                                  (or (keyword? (first exprs))
                                      (symbol? (first exprs)))
                                  (map? (second exprs)))]
                 (cond (and hiccup? (not (:fn-format (:vector opts))))
                       {:vector {:fn-format :arg1-force-nl}}
                       (and (not hiccup?) (:fn-format (:vector opts)))
                       {:vector {:fn-format nil}}
                       :else nil)))}
 :vector-fn
 {:indent 1
  :indent-arg 1}}
```
For example
```cljs
(defn header [{:keys [title icon description]}]
  [:header.container
   [:div.cols {:class "gap top" 
:on-click (fn [] (println "tsers"))}
    [:div {:class "shrink"} icon]
    [:div.rows {:class "gap-xs"}
     [:dov.cols {:class "middle between"}
      [:div title] [:div {:class "shrink"} [:button "x"]]]
     [:div description]]]])

(defn app []
  [:div.app
   [header {:icon [icon/star {:color colors/blue}]
     :title       [:h2 "Tsers!!"]
     :description [max-lines  {:lines 3}
                   [:span "Lorem ipsum dolor sit amet, consectetur adipiscing elit."]
                   [:span "Vestibulum maximus rutrum elit vel tincidunt. Nulla facilisi. Phasellus quis felis odio. Nullam euismod velit ut dignissim aliquam. Aenean interdum hendrerit dapibus. In quam felis, feugiat quis consectetur nec, volutpat a nisi. Sed lacinia, dui eget dapibus pharetra, leo justo ornare libero, et tempor arcu elit et ligula. Vestibulum in mi lectus.\n\nUt blandit egestas purus, sed gravida mauris pharetra in. Nulla facilisis eget ipsum nec viverra. Ut finibus facilisis metus, vitae scelerisque elit aliquet a. Proin suscipit dictum massa, sit amet tincidunt lorem fringilla vel. Etiam facilisis blandit aliquam. Ut sodales mi id consectetur tempor. Sed nunc risus, scelerisque nec blandit vel, auctor non elit."]]}]
   [:hr]])

;; >> becomes

(defn header
  [{:keys [title icon description]}]
  [:header.container
   [:div.cols {:class "gap top", :on-click (fn [] (println "tsers"))}
    [:div {:class "shrink"}
     icon]
    [:div.rows {:class "gap-xs"}
     [:dov.cols {:class "middle between"}
      [:div title]
      [:div {:class "shrink"}
       [:button "x"]]]
     [:div description]]]])

(defn app
  []
  [:div.app
   [header
    {:icon [icon/star {:color colors/blue}],
     :title [:h2 "Tsers!!"],
     :description
       [max-lines {:lines 3}
        [:span "Lorem ipsum dolor sit amet, consectetur adipiscing elit."]
        [:span
         "Vestibulum maximus rutrum elit vel tincidunt. Nulla facilisi. Phasellus quis felis odio. Nullam euismod velit ut dignissim aliquam. Aenean interdum hendrerit dapibus. In quam felis, feugiat quis consectetur nec, volutpat a nisi. Sed lacinia, dui eget dapibus pharetra, leo justo ornare libero, et tempor arcu elit et ligula. Vestibulum in mi lectus.\n\nUt blandit egestas purus, sed gravida mauris pharetra in. Nulla facilisis eget ipsum nec viverra. Ut finibus facilisis metus, vitae scelerisque elit aliquet a. Proin suscipit dictum massa, sit amet tincidunt lorem fringilla vel. Etiam facilisis blandit aliquam. Ut sodales mi id consectetur tempor. Sed nunc risus, scelerisque nec blandit vel, auctor non elit."]]}]
   [:hr]])
```

What do you think?

Cheers!