### PR TITLE
Fixed spec.cljc NS declaration to require clojure.string

### DIFF
--- a/src/zprint/spec.cljc
+++ b/src/zprint/spec.cljc
@@ -1,8 +1,9 @@
 (ns ^:no-doc zprint.spec
   #?@(:cljs [[:require-macros [zprint.smacros :refer [only-keys]]]])
-  (:require #?@(:clj [[zprint.smacros :refer [only-keys]]
-                      [clojure.spec.alpha :as s]]
-                :cljs [[cljs.spec.alpha :as s]])))
+  (:require [clojure.string :as string]
+    #?@(:clj [[zprint.smacros :refer [only-keys]]
+              [clojure.spec.alpha :as s]]
+        :cljs [[cljs.spec.alpha :as s]])))
 
 ;;
 ;; # Compatibility
@@ -378,7 +379,7 @@
           [key-choice min-via] (first (sort-by second key-via-len-seq))
           problem (first (filter (comp (partial = min-via) count :via)
                            (val-map key-choice)))]
-      (cond (clojure.string/ends-with? (str (:pred problem)) "?")
+      (cond (string/ends-with? (str (:pred problem)) "?")
               (str (ks-phrase problem)
                    " was not a " (map-pred (str (:pred problem))))
             (set? (:pred problem)) (str (ks-phrase problem)

--- a/src/zprint/spec.cljc
+++ b/src/zprint/spec.cljc
@@ -1,9 +1,9 @@
 (ns ^:no-doc zprint.spec
   #?@(:cljs [[:require-macros [zprint.smacros :refer [only-keys]]]])
   (:require [clojure.string :as string]
-    #?@(:clj [[zprint.smacros :refer [only-keys]]
-              [clojure.spec.alpha :as s]]
-        :cljs [[cljs.spec.alpha :as s]])))
+            #?@(:clj [[zprint.smacros :refer [only-keys]]
+                      [clojure.spec.alpha :as s]]
+                :cljs [[cljs.spec.alpha :as s]])))
 
 ;;
 ;; # Compatibility
@@ -379,7 +379,7 @@
           [key-choice min-via] (first (sort-by second key-via-len-seq))
           problem (first (filter (comp (partial = min-via) count :via)
                            (val-map key-choice)))]
-      (cond (string/ends-with? (str (:pred problem)) "?")
+      (cond (clojure.string/ends-with? (str (:pred problem)) "?")
               (str (ks-phrase problem)
                    " was not a " (map-pred (str (:pred problem))))
             (set? (:pred problem)) (str (ks-phrase problem)


### PR DESCRIPTION
Eliminates warning from some build-tooling on use of undeclared var.

Specifically, I was getting this warning on every build/reload my shadow-cljs browser app during development.

```
------ WARNING #1 - :undeclared-var --------------------------------------------
 Resource: zprint/spec.cljc:381:14
 Use of undeclared Var clojure.string/ends-with?
--------------------------------------------------------------------------------
```

Please edit as desired & thanks for the library!