### PR TITLE
Fix 2 tests that fail when line.separator is CRLF

### DIFF
--- a/test/zprint/zprint_test.cljc
+++ b/test/zprint/zprint_test.cljc
@@ -4585,9 +4585,16 @@ ser/collect-vars-acc %1 %2) )))"
 
   ;; Establish that we have some difference between colored and non-colored
 
-  (expect 14 (count (zprint-str "(a :b \"c\")" {:color? false})))
+  (let [s "(a :b \"c\")"
+        cf {:color? false}
+        ct {:color? true}]
+    (expect 14 (count (zprint-str s cf)))
 
-  (expect 23 (count (zprint-str "(a :b \"c\")" {:color? true})))
+    (expect 23 (count (zprint-str s ct)))
+
+    (expect (zprint-str s cf) (str/trim-newline (with-out-str (zprint s cf))))
+
+    (expect (zprint-str s ct) (str/trim-newline (with-out-str (zprint s ct)))))
 
   ;; See if those differences match what we expect
 
@@ -4602,10 +4609,6 @@ ser/collect-vars-acc %1 %2) )))"
 
   (expect (czprint-str "(a :b \"c\")" {:color? false})
           (zprint-str "(a :b \"c\")"))
-
-  (expect 15 (count (with-out-str (zprint "(a :b \"c\")" {:color? false}))))
-
-  (expect 24 (count (with-out-str (zprint "(a :b \"c\")" {:color? true}))))
 
   ;; See if those differences match what we expect
 


### PR DESCRIPTION
In `zprint_test.cljc` there are some tests contrasting the use of `(zprint-str ...)` and `(with-out-str (zprint ...))`. The `with-out-str` version expects one more character than the `zprint-str` version, since `with-out-str` adds a trailing line separator. The tests work on linux and mac where EOL is only one character, but fail on windows where the line separator (`"\r\n"`) is two characters long.

This pull request fixes the situation by comparing the `zprint-str` call to the trimmed `with-out-str` call. With this change, `lein test` passes all tests on Windows.

An alternate approach would be to expect the same count as the `zprint-str` call plus `(count (System/getProperty "line.separator"))`.
