### PR TITLE
Fix lock / unlock reflection error

### DIFF
--- a/src/zprint/redef.cljc
+++ b/src/zprint/redef.cljc
@@ -32,8 +32,8 @@
        zlock-enable is true, because graalvm will compile with the
        following code, but will throw an exception since it is
        unable to find the unlock method."
-       [^ReentrantLock x & body]
-       `(let [lockee# ~x]
+       [x & body]
+       `(let [^ReentrantLock lockee# ~x]
           (try (if @zlock-enable (. lockee# (lock)))
                ~@body
                (if @zlock-enable (. lockee# (unlock)))


### PR DESCRIPTION
Not sure why, possibly because of macro expansion, but I was getting reflections errors for the `lock` and `unlock` methods. Moving the type hint into the let fixes this issue.

```
Reflection warning, zprint/redef.cljc:65:8 - call to method unlock can't be resolved (target class is unknown).
Reflection warning, zprint/redef.cljc:65:8 - call to method unlock can't be resolved (target class is unknown).
Reflection warning, zprint/redef.cljc:100:15 - call to method lock can't be resolved (target class is unknown).
Reflection warning, zprint/redef.cljc:100:15 - call to method unlock can't be resolved (target class is unknown).
Reflection warning, zprint/redef.cljc:100:15 - call to method unlock can't be resolved (target class is unknown).
```