### PR TITLE
Run tests in babashka

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,23 @@
+{:paths ["src"]
+ :deps {org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
+                                 :git/sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}}
+ :tasks {test:bb {:extra-paths ["test"]
+                  :extra-deps {com.github.seancorfield/expectations
+                               {:mvn/version "2.0.143"}
+                               io.github.cognitect-labs/test-runner
+                               {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
+                               org.clojure/tools.namespace {:git/url "https://github.com/babashka/tools.namespace"
+                                                            :git/sha "3625153ee66dfcec2ba600851b5b2cbdab8fae6c"}
+                               cljc.java-time {:mvn/version "0.1.11"}}
+                  :requires ([cognitect.test-runner :as tr])
+                  :task (apply tr/-main
+                               "-d" "test"
+                               "-n" "zprint.core-test"
+                               "-n" "zprint.finish-test"
+                               "-n" "zprint.guide-test"
+                               "-n" "zprint.main-test"
+                               "-n" "zprint.range-test"
+                               "-n" "zprint.rewrite-test"
+                               "-n" "zprint.spec-test"
+                               "-n" "zprint.zutil-test"
+                               *command-line-args*)}}}

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
  :deps {#_#_org.clojure/clojure {:mvn/version "1.9.0"},
         #_#_org.clojure/clojurescript {:mvn/version "1.9.946"},
         #_#_org.clojure/clojure {:mvn/version "1.10.3"},
-        org.babashka/sci {:mvn/version "0.2.8"},
+        org.babashka/sci {:mvn/version "0.3.2"},
         ;; To use zprint with babashka, include the following dependency:
         ;; org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
         ;;                          :git/sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}

--- a/deps.edn
+++ b/deps.edn
@@ -20,13 +20,9 @@
  :deps {#_#_org.clojure/clojure {:mvn/version "1.9.0"},
         #_#_org.clojure/clojurescript {:mvn/version "1.9.946"},
         #_#_org.clojure/clojure {:mvn/version "1.10.3"},
-        #_#_borkdude/sci {:mvn/version "0.2.5"},
         org.babashka/sci {:mvn/version "0.2.8"},
-        ; To use zprint with babashka, include the following dependency:
-        ;
-        ;borkdude/spartan.spec {:git/url
-        ;                        "https://github.com/borkdude/spartan.spec",
-        ;                       :sha
-        ;                       "12947185b4f8b8ff8ee3bc0f19c98dbde54d4c90"},
+        ;; To use zprint with babashka, include the following dependency:
+        ;; org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
+        ;;                          :git/sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}
         rewrite-clj/rewrite-clj {:mvn/version "1.0.699-alpha"}},
  :paths ["src" "test" "cljs-test-runner-out/gen"]}

--- a/src/zprint/main.cljc
+++ b/src/zprint/main.cljc
@@ -305,7 +305,7 @@
   [& args]
   ; Turn off multi-zprint locking since graalvm can't handle it, and
   ; we only do one zprint at a time here in the uberjar.
-  (zprint.redef/remove-locking)
+  #?(:bb nil :clj (zprint.redef/remove-locking))
   (let [debug? (and args (= (first args) ":debug"))
         args (if debug? (next args) args)
         before-last-switch (elements-before-last-switch args)

--- a/test/zprint/core_test.cljc
+++ b/test/zprint/core_test.cljc
@@ -531,7 +531,8 @@
   ;; or a structure when we are already using it on the other thing.
   ;;
 
-  #?(:clj
+  #?(:bb nil
+     :clj
        (defn multi-test-fail
          "Test the multithreaded capabilities and that they fail when they are  
   supposed to.  This *should* fail!!!."
@@ -564,7 +565,8 @@
                               {:parse-string-all? true, :color? false})))
 
 
-  #?(:clj
+  #?(:bb nil
+     :clj
        (expect
          "multi-test-fail got an exception as it was supposed to do"
          (try


### PR DESCRIPTION
This PR provides support to run the namespaces that are babashka-compatible with babashka, using a task in bb.edn:

```
bb test:bb
```