### PR TITLE
Change formatting of "while" to arg1-body

### DIFF
--- a/src/zprint/config.cljc
+++ b/src/zprint/config.cljc
@@ -416,6 +416,7 @@
    "when-let" :binding,
    "when-not" :arg1-body,
    "when-some" :binding,
+   "while" :arg1-body
    "with-bindings" :arg1,
    "with-bindings*" :arg1,
    "with-local-vars" :binding,


### PR DESCRIPTION
`while` has no special formatting currently, so it currently attempts to hang the body:

```clojure
(def a (atom 10))

(while (pos? @a)
       (println @a)
       ;; comment to not put on one line
       (swap! a dec))
```

Given that it [works like `when`](https://clojuredocs.org/clojure.core/while), I think it should be formatted like `when` too (flow the body):

```clojure
(def a (atom 10))

(while (pos? @a)
  (println @a)
  ;; comment to not put on one line
  (swap! a dec))
```

Given that `while` isn't used very often, I think this should be a small change overall.