### PR TITLE
Add CI workflow for main branch

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -1,0 +1,168 @@
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-jar:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+
+      - name: Version
+        id: version
+        # Get version from project.clj
+        run: echo ::set-output name=zprint::$(awk -F "\"" '{print $2}' project.clj | head -n 1)
+
+      - name: Setup Clojure
+        uses: zharinov/clj-toolbox@v1.0.0
+        with:
+          leiningen: "2.9.10"
+
+      - name: Uberjar
+        run: lein uberjar
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: jar-files
+          path: target/zprint-filter-${{ steps.version.outputs.zprint }}
+
+  build-native:
+    needs: build-jar
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3.0.0
+        with:
+          name: jar-files
+          path: target/
+
+      - name: Version
+        id: version
+        # Get version from uberjar name
+        run: echo ::set-output name=zprint::$(ls target/zprint-filter-* | sed 's/.*zprint-filter-//')
+
+      - name: Setup GraalVM
+        uses: zharinov/clj-toolbox@v1.0.0
+        with:
+          java: graalvm
+          java-version: 17
+
+      - name: Native image
+        env:
+          LC_ALL: C.UTF-8
+        run: native-image
+          --no-server
+          -J-Xmx7G
+          -J-Xms4G
+          -jar target/zprint-filter-${{ steps.version.outputs.zprint }}
+          -H:Name="zprintl-${{ steps.version.outputs.zprint }}"
+          -H:EnableURLProtocols=https,http
+          -H:+ReportExceptionStackTraces
+          --report-unsupported-elements-at-runtime
+          --initialize-at-build-time
+          --no-fallback
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: zprintl
+          path: zprintl-${{ steps.version.outputs.zprint }}
+
+  test-native:
+    needs: build-native
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+
+      - name: Setup Babashka
+        uses: zharinov/clj-toolbox@v1.0.0
+        with:
+          babashka: "0.9.161"
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3.0.0
+        with:
+          name: zprintl
+
+      - name: Version
+        id: version
+        # Get version from binary name
+        run: echo ::set-output name=zprint::$(ls zprintl-* | sed 's/zprintl-//')
+
+      - run: chmod +x zprintl-${{ steps.version.outputs.zprint }}
+
+      - name: Run tests
+        run: ./test_config ${{ steps.version.outputs.zprint }} graalvm-linux
+
+  test-clj:
+    needs: build-jar
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+
+      - name: Setup Clojure
+        uses: zharinov/clj-toolbox@v1.0.0
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3.0.0
+        with:
+          name: jar-files
+          path: target/
+
+      - name: Run tests
+        run: clojure -Srepro -M:cljtest:humane:runner
+
+  test-jar:
+    needs: build-jar
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+
+      - name: Version
+        id: version
+        # Get version from project.clj
+        run: echo ::set-output name=zprint::$(awk -F "\"" '{print $2}' project.clj | head -n 1)
+
+      - name: Setup Clojure
+        uses: zharinov/clj-toolbox@v1.0.0
+        with:
+          babashka: "0.9.161"
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3.0.0
+        with:
+          name: jar-files
+          path: target/
+
+      - name: Run tests
+        run: ./test_config ${{ steps.version.outputs.zprint }} uberjar
+
+  test-cljs:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+
+      - name: Setup Clojure
+        uses: zharinov/clj-toolbox@v1.0.0
+
+      - name: Install Planck
+        run: brew install planck
+
+      - name: ClojureScript tests
+        run: clojure -M:cljs-runner


### PR DESCRIPTION
Thank you for kind words regarding my work on Pull Request CI workflow.
Here we go a little bit further and enable workflow running on the main branch after every PR merge.

<img width="892" alt="imagen" src="https://user-images.githubusercontent.com/1239644/190701698-73b95c17-499d-40fb-9e62-442f63312cd1.png">

As you may notice, many repositories have this orange dot near to the commit SHA. It's clickable and it points to CI run for the main branch, not the PR.

`main-branch.yml` duplicates everything `pull-request.yml` does, but additionally performs `test-cljs` run which lasts ~10 minutes. Because it was slower than other tests from the PR workflow, I include it here on the main branch. This way, when ClojureScript builds are failing (which I hope is rare occasion), you at least will know this before shipping new release.

Unfortunately, there is no straightforward ways for YAML code reuse in GitHub Actions, so it's mostly a copy-paste of previous yaml file.

See also example run on the `main` branch of my `zprint` fork: https://github.com/zharinov/zprint/actions/runs/3069699879

Once this PR is merged, the next step will be to add additional `native-image` build steps for missing platforms, so that for every commit in `main` branch you will have `zprintl`, `zprintm` and `zprint-filter` binaries available for testing.