### PR TITLE
Macos binary instructions updated with adding necessary permissions

### DIFF
--- a/doc/getting/macos.md
+++ b/doc/getting/macos.md
@@ -43,9 +43,14 @@ you called it), by giving it the -v switch:
 zprint-1.2.3
 ```
 
+Note that sometimes in macos to run the binary like `./zprint -v`, you need to first do two steps:
+1. Give execute access `chmod +x ./zprint`
+2. Give it trusted status by: right-clicking on the binary and choosing "Open with" -> iterm/terminal -> it should give you a message about Macos not being able to verify it to which you need to respond with clicking "Open"
+
 ### 4. Put zprint into a directory in your path
 To be able to run zprint it needs to be in a directory that appears in
 your path.
+
 
 ## Install from Homebrew
 


### PR DESCRIPTION
When trying to follow instructions in https://github.com/kkinnear/zprint/issues/310 I've found that those steps were missing in my macos to start the binary.