### PR TITLE
Fix missing line breaks in the reference doc

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -1311,7 +1311,9 @@ possible.  Later arguments are indented the amount specified by
 ```clojure
  (if (= a 1)
    (map inc coll) (map dec coll))
-``` #### :arg1-pair
+```
+
+#### :arg1-pair
 
 The function has an important first argument, then the rest of the
 arguments are paired up. Leftmost part of the pair is indented by
@@ -1321,7 +1323,9 @@ if it is not.
 ```clojure
  (assoc my-map
    :key1 :val1 :key2 :val2)
-``` #### :arg1-pair-body
+```
+
+#### :arg1-pair-body
 
 The function has an important first argument, then the rest of the
 arguments are paired up.  The leftmost part of the pair is indented

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -1521,7 +1521,7 @@ Print the first argument on the same line as the function, if
 possible.  Later arguments go indented and `:arg1` and `:arg-1-pair`
 top level fns are become `:none` and `:pair`, respectively.
 
-Currently `->` is `:narg1-body`, however, and there are no `:arg1->`
+Currently `->` is `:noarg1-body`, however, and there are no `:arg1->`
 functions.
 
 ```clojure
@@ -5249,7 +5249,7 @@ given by the `:key-depth-color` vector.
 
 The value of `:key-value-options` is a map which relates map keys to options
 maps used to format the values of those map keys.  This capability, had
-it been around earlier, would make :key-value-color` unnecessary.  
+it been around earlier, would make `:key-value-color` unnecessary.  
 It would also have made `:key-ignore` unnecessary, as the options map
 for a specific key could specify a `:max-length` which was very short.
 While it seems simple, this is a particularly powerful formatting

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -1383,9 +1383,10 @@ by `:pair {:indent n}`.
 ```clojure
   (condp = stuff
     :bother "bother" :foo "foo" :bar "bar" "baz")
-``` Note: This is implemented as a "body" function, as if it were
-`:arg2-pair-body`.
+```
 
+Note: This is implemented as a "body" function, as if it were
+`:arg2-pair-body`.
 
 #### :arg2-fn
 


### PR DESCRIPTION
Adds 3 missing line breaks in the `reference.md` file, "Function Classification for Pretty Printing" section.