### PR TITLE
Get rid of auto-boxing reflection warnings

### DIFF
--- a/src/zprint/comment.cljc
+++ b/src/zprint/comment.cljc
@@ -527,9 +527,9 @@
          "end-cg" end-cg)
   (loop [idx index
          depth depth
-         start-col 0
-         number-semis 0 ; non-zero says we currently in a group
-         current-spacing 0
+         start-col (Long/valueOf 0)
+         number-semis (Long/valueOf 0) ; non-zero says we currently in a group
+         current-spacing (Long/valueOf 0)
          nl-indent-count 0
          out [nil 0 0]]
     ; Find the start of the comment group
@@ -1094,8 +1094,8 @@
            ((:dzprint options)
              {}
              (map #(vector %1 %2 %3) (range) start-col style-vec)))
-    (loop [idx 0
-           depth 0
+    (loop [idx       (Long/valueOf 0)
+           depth     (Long/valueOf 0)
            style-vec style-vec]
       (let [[new-depth comment-group]
               (get-next-comment-group options depth idx start-col style-vec)
@@ -1174,9 +1174,9 @@
   #_(def fcic style-vec)
   (loop [cvec style-vec
          index 0
-         last-indent 0
+         last-indent (Long/valueOf 0)
          current-seq []
-         current-column 0
+         current-column (Long/valueOf 0)
          distance 0
          out []]
     (if-not cvec
@@ -1259,7 +1259,7 @@
   #_(def fcic style-vec)
   (loop [cvec style-vec
          index 0
-         last-indent 0
+         last-indent (Long/valueOf 0)
          current-seq []
          out []]
     (if-not cvec
@@ -1327,7 +1327,7 @@
                :cljs js/Error.)
             (str "comment-column: style-vec not a vector!! " style-vec))))
   (loop [index indent-index
-         column 0]
+         column (Long/valueOf 0)]
     (if (= index comment-index)
       column
       (recur (inc index) (loc-vec column (nth style-vec index))))))

--- a/src/zprint/focus.cljc
+++ b/src/zprint/focus.cljc
@@ -78,7 +78,7 @@
   "Given a non-whitespace path from a zipper, find that same
   collection or element in a str-style-vec."
   [nwpath ssv]
-  (loop [idx 0
+  (loop [idx (Long/valueOf 0)
          nwp nwpath]
     (when idx
       (if (empty? nwp)

--- a/src/zprint/range.cljc
+++ b/src/zprint/range.cljc
@@ -107,8 +107,8 @@
      (println "find-row: linenumber:" linenumber "scan-size:" scan-size))
    (let [size (count row-vec)]
      ; We are 1 based, because edamame row numbers are 1 based.
-     (loop [row-vec-index (int (/ size 2))
-            previous-index 0
+     (loop [row-vec-index (Long/valueOf (quot size 2))
+            previous-index (Long/valueOf 0)
             tries 0]
        #_(println "\n\n================== row-vec-index:" row-vec-index)
        (if (> tries 10)


### PR DESCRIPTION
Currently, when one imports zprint, this is the output:

```
[~/work/zprint] clj
Clojure 1.12.0
user=> (set! *warn-on-reflection* true)
true
user=> (require 'zprint.core)
comment.cljc:602 recur arg for primitive local: start_col is not matching primitive, had: Object, needed: long
comment.cljc:602 recur arg for primitive local: number_semis is not matching primitive, had: Object, needed: long
comment.cljc:602 recur arg for primitive local: current_spacing is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: start-col
Auto-boxing loop arg: number-semis
Auto-boxing loop arg: current-spacing
comment.cljc:1122 recur arg for primitive local: idx is not matching primitive, had: Object, needed: long
comment.cljc:1122 recur arg for primitive local: depth is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: idx
Auto-boxing loop arg: depth
comment.cljc:1192 recur arg for primitive local: last_indent is not matching primitive, had: Object, needed: long
comment.cljc:1206 recur arg for primitive local: last_indent is not matching primitive, had: Object, needed: long
comment.cljc:1206 recur arg for primitive local: current_column is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: last-indent
Auto-boxing loop arg: current-column
comment.cljc:1288 recur arg for primitive local: last_indent is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: last-indent
comment.cljc:1333 recur arg for primitive local: column is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: column
focus.cljc:86 recur arg for primitive local: idx is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: idx
range.cljc:134 recur arg for primitive local: row_vec_index is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: row-vec-index
range.cljc:134 recur arg for primitive local: previous_index is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: row-vec-index
Auto-boxing loop arg: previous-index
nil
```

After patch:

```
[~/work/zprint] clj
Clojure 1.12.0
user=> (set! *warn-on-reflection* true)
true
user=> (require 'zprint.core)
nil
```