### PR TITLE
Triage over-allocation issue

### DIFF
--- a/src/zprint/finish.cljc
+++ b/src/zprint/finish.cljc
@@ -29,7 +29,7 @@
 
 (defn ground-color-to-style
   "Ignore any foreground/background designation, and use the
-  focus and the color to figure out a style.  Intimately 
+  focus and the color to figure out a style.  Intimately
   associated with build-styles.
   You don't have to have a color, but you do need a ground.
   If the ground is :c, it is used, otherwise the ground is
@@ -62,7 +62,7 @@
 (defn gc-vec-to-style-vec
   "Take an index and a [string :color element] and produce a
   [string :style element] with the correct elements (i.e., the
-  elements with the correct idx) having a different 
+  elements with the correct idx) having a different
   background for focus output. The ctx is a map which
   must have a :style-map and may have a :focus.  The
   :focus is a two element vector of start and end elements
@@ -146,17 +146,17 @@
         (recur (next remaining-cvec) new-idx (conj out new-idx))))))
 
 (defn cvec-to-style-vec
-  "Take a [[string :color <anything>] 
+  "Take a [[string :color <anything>]
            [string :color <anything>] ...] input.
-  The focus is a vector of [start-focus end-focus] which are the 
-  inclusive values for the focus.  The end is inclusive because it 
-  gets a bit dicey if it was 'beyond', since how much beyond would 
+  The focus is a vector of [start-focus end-focus] which are the
+  inclusive values for the focus.  The end is inclusive because it
+  gets a bit dicey if it was 'beyond', since how much beyond would
   be interesting given the amount of whitespace in the input.
   Not clear at this point just what the counts in the focus-vec count,
   possibly things with <anything> == :element, possibly just any
   [string color <anything>] vector.
   From this, build of: [[string :style] [string :style] ...], where
-  :style might be a color, like :blue or :none, or it might be a 
+  :style might be a color, like :blue or :none, or it might be a
   java-text-pane style (which would have a color encoded in it).  This
   is based on the :style-map in the ctx map. Note that this :style-map
   doesn't have any relation to the :style-map in the options map."
@@ -188,27 +188,26 @@
 
 (defn compress-style
   "Take a [[string :style] [string :style] ...] vector and
-  build a list of: [[string :style <start> <length>] 
+  build a list of: [[string :style <start> <length>]
                     [string :style <start> <length>]...]
   from it.  This will compress strings which have the same style."
   ([str-style-vec initial-pos]
-   (loop [ss-vec str-style-vec
+   (loop [ss-vec  str-style-vec
           current nil
-          pos initial-pos
-          out []]
+          pos     initial-pos
+          out     []]
      (let [ss (first ss-vec)]
        (if-not ss
-         (conj out (add-length current))
+         (conj out (add-length (when current (update current 0 #(apply str %)))))
          (let [same-style? (= (second current) (second ss))]
            (recur (next ss-vec)
-                  (if same-style?
-                    [(str (first current) (first ss)) (second current)
-                     (nth current 2)]
-                    [(first ss) (second ss) pos])
+                  (if (and same-style? current)
+                    [(conj (first current) (first ss)) (second current) (nth current 2)]
+                    [[(first ss)] (second ss) (if same-style? (nth current 2) pos)])
                   (+ pos (count (first ss)))
                   (if (or same-style? (= initial-pos pos))
                     out
-                    (conj out (add-length current)))))))))
+                    (conj out (add-length (when current (update current 0 #(apply str %))))))))))))
   ([str-style-vec] (compress-style str-style-vec 0)))
 
 ;;
@@ -219,11 +218,11 @@
 ;;
 
 (defn replace-focus-w-cursor
-  "Take a [[string :color <anything>] 
+  "Take a [[string :color <anything>]
            [string :color <anything>] ...] as input.
   and a focus-vec and, possibly, a non-empty cursor-vec.  If
   there is a cursor-vec, replace the focus-vec items with a cursor
-  vec and return a new focus-vec and gcw-vec as [focus-vec gcw-vec], 
+  vec and return a new focus-vec and gcw-vec as [focus-vec gcw-vec],
   else just return with no changes"
   [gcw-vec [focus-start focus-end :as focus-vec] cursor-vec]
   (if (empty? cursor-vec)
@@ -334,7 +333,7 @@
         [nl-num where]))))
 
 (defn cvec-lines
-  "Return a vector containing vectors each with the cvec elements 
+  "Return a vector containing vectors each with the cvec elements
   for the start and end of each line."
   [cvec]
   (loop [cvec-nl (map (comp newline-vec first) cvec)
@@ -373,7 +372,7 @@
 
 (defn surround-focus
   "Given a cvec and a focus-vec, and the number of line before and after
-  the focus, output a vector of vectors of cvec indicies that cover the 
+  the focus, output a vector of vectors of cvec indicies that cover the
   desired lines. [[start end] [start end] ...]"
   [lines-to-cvec [focus-begin focus-end] [before after]]
   (let [line-count (count lines-to-cvec)


### PR DESCRIPTION
Hello!

At my company, we have zprint run over 40 files that are ~10s of megabytes apiece. They encode integrity test results, so we've really enjoyed having them pretty-printed for review. This process has started taking a minute or two for several of us, but one of our coworkers is on a memory constrained virtual machine. He recently tried to run the formatting job, and it took nearly an hour. This PR is the result of running that job with [clj-async-profiler](https://github.com/clojure-goes-fast/clj-async-profiler)- Eventually using the [Allocation Profiler](https://clojure-goes-fast.com/kb/profiling/clj-async-profiler/allocation-profiling/) to find the root cause

## Research

I ran the formatting against a single file, and found this hot spot:

<img width="1901" height="455" alt="Screenshot 2026-08-26 at 6 44 23 PM" src="https://github.com/user-attachments/assets/f53d804b-f4fd-420f-9da1-583d4df4d897" />

(Virtually all of the allocations are in service of incrementally building strings within `zprint.finish/compress-style`)

I tested the below fix locally (via `with-redefs`) to produce this comparative profile:

<img width="1897" height="890" alt="Screenshot 2026-08-26 at 6 49 05 PM" src="https://github.com/user-attachments/assets/b9ffe03b-bc01-427c-b4dc-cd924d2c87a7" />

(The shimmed version of compress style is now ~6% of all allocations)

## PR

The `same-style?` inner-branch keeps rebuilding the full string. We were in a position where we hit this branch almost 100% of the time. Instead of rebuilding strings each pass, I made a change to collect them and only generate the string to compute size once.

Sorry about the whitespace diffs, VSCode auto-trims them for me. I can revert those if you don't want them. I've been able to run the test with babashka separately, and this code does have some coverage. I was also able to verify that it produces the same output in the tool I was originally using. I'm happy to do any other verification/testing you'd like too!